### PR TITLE
Maintenance Updates 2026-03-06

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,11 +7,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.14"
+      - name: Get version
+        id: version
+        run: echo "version=$(grep -m1 '__version__' hyperborea3/__init__.py | cut -d'"' -f2)" >> $GITHUB_OUTPUT
       - name: Build
         run: uv build --clear
       - name: Upload dist
@@ -36,3 +41,15 @@ jobs:
           path: dist/
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  tag:
+    runs-on: ubuntu-latest
+    needs: [build, publish]
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Create and push tag
+        run: |
+          git tag v${{ needs.build.outputs.version }}
+          git push origin v${{ needs.build.outputs.version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,20 @@ jobs:
           python-version: "3.14"
       - name: Install dependencies
         run: uv sync --extra=test --frozen
+      - name: Version Check
+        run: |
+          git fetch origin main --depth=1
+          CURRENT=$(grep -m1 '__version__' hyperborea3/__init__.py | cut -d'"' -f2)
+          MAIN=$(git show origin/main:hyperborea3/__init__.py | grep -m1 '__version__' | cut -d'"' -f2)
+          python3 -c "
+          current = tuple(int(x) for x in '$CURRENT'.split('.'))
+          main = tuple(int(x) for x in '$MAIN'.split('.'))
+          assert current > main, f'Version $CURRENT must be higher than main ($MAIN)'
+          "
+      - name: Changelog Check
+        run: |
+          VERSION=$(grep -m1 '__version__' hyperborea3/__init__.py | cut -d'"' -f2)
+          grep -q "## \[$VERSION\]" changelog.md || (echo "No changelog entry for v$VERSION" && exit 1)
       - name: Lint Check
         run: uv run ruff check .
       - name: Format Check

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ settings.json
 *.pyc
 build/
 dist/
+game_files/
 local/
 .venv
 .coverage

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2] - 2026-03-06
+### Added
+- Changelog version check in CI (`tests.yml`) — PRs now fail if `changelog.md` has no entry matching the current version
+- Automatic git tagging in publish workflow (`publish.yml`) — a `v{version}` tag is pushed after each successful PyPI publish
+
+## [0.7.1] - 2026-03-06
+### Changed
+- Migrated build backend from `setuptools` to `hatchling`
+- Replaced `twine` with `uv-publish` for publishing to PyPI
+- `build_wheel` now uses `uv build`
+- `deploy_test` now uses `uv run uv-publish` to upload to Test PyPI
+- `deploy_prod` is now handled automatically via GitHub Actions on merge to main
+- `make install` / `make create_venv` / CI / Dockerfile all use `--frozen` for reproducible installs
+### Added
+- `.github/workflows/publish.yml` — automatically publishes to PyPI on merge to main via OIDC trusted publishing
+- `make upgrade_deps` — upgrades all dependencies and updates `uv.lock`
+### Removed
+- `MANIFEST.in` — unused by hatchling
+- `.flake8` — superseded by ruff
+
 ## [0.7.0] - 2026-02-13
 ### Changed
 - use `uv` in place of `pyenv` and `pip-tools`

--- a/hyperborea3/__init__.py
+++ b/hyperborea3/__init__.py
@@ -1,7 +1,7 @@
 import logging
 import os
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"
 
 
 def get_debug() -> bool:


### PR DESCRIPTION
## Summary

### CI (`tests.yml`)
- **Version Check**: PRs now fail if the version in `__init__.py` is not strictly higher than the version on `main`
- **Changelog Check**: PRs now fail if `changelog.md` has no entry matching the current version

### Publish workflow (`publish.yml`)
- **Auto-tagging**: after a successful PyPI publish, a `v{version}` git tag is automatically created and pushed

### Other
- Added `game_files/` to `.gitignore`
- Updated `changelog.md` with entries for `0.7.1` and `0.7.2`
- Bumped version to `0.7.2`